### PR TITLE
Browser and spec compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ var chunk = (function(chunk){
     { name: 'getComment',       regex: /(([\s\S]*?)\-\->)/g },
     { name: 'getScript',        regex: /(([\s\S]*?)<\/script>)/g },
     { name: 'getTagEnd',        regex: /(\s*(\/?>))/g },
-    { name: 'getAttributeName', regex: /(\s+(([a-z0-9\-]+:)?[a-z0-9\-]+)(\s*=\s*)?)/ig }
+    { name: 'getAttributeName', regex: /(\s+(([a-z0-9\-_]+:)?[a-z0-9\-_]+)(\s*=\s*)?)/ig }
   ], function(item) {
     chunk[item.name] = function(str, pos) {
       item.regex.lastIndex = pos

--- a/index.js
+++ b/index.js
@@ -152,15 +152,15 @@ var states = {
 // -----------------------------------------------
 
 var chunk = (function(chunk){
-  ;[{ name: 'getOpeningTag',    regex: /(<(([a-z0-9\-]+:)?[a-z0-9\-]+))/ig },
+  _.forEach([{ name: 'getOpeningTag',    regex: /(<(([a-z0-9\-]+:)?[a-z0-9\-]+))/ig },
     { name: 'getText',          regex: /([^<]+)/g },
     { name: 'getClosingTag',    regex: /(<\/(([a-z0-9\-]+:)?[a-z0-9\-]+)>)/ig },
     { name: 'getCommentOpen',   regex: /(<!\-\-)/g },
     { name: 'getComment',       regex: /(([\s\S]*?)\-\->)/g },
     { name: 'getScript',        regex: /(([\s\S]*?)<\/script>)/g },
     { name: 'getTagEnd',        regex: /(\s*(\/?>))/g },
-    { name: 'getAttributeName', regex: /(\s+(([a-z0-9\-]+:)?[a-z0-9\-]+)(\s*=\s*)?)/ig },
-  ].forEach(function(item) {
+    { name: 'getAttributeName', regex: /(\s+(([a-z0-9\-]+:)?[a-z0-9\-]+)(\s*=\s*)?)/ig }
+  ], function(item) {
     chunk[item.name] = function(str, pos) {
       item.regex.lastIndex = pos
       var match = item.regex.exec(str)

--- a/parser.js
+++ b/parser.js
@@ -141,7 +141,7 @@ var isClosedByParent = (function() {
 
 function makeLookup(str) {
   var obj = {}
-  str.split(',').forEach(function(x) { obj[x] = true })
+  _.forEach(str.split(','), function(x) { obj[x] = true })
   return obj
 }
 


### PR DESCRIPTION
Tried to use this to parse HTML for a project with IE8 support and ran into two issues.
First, Array.forEach wasn't available. Since this project uses lodash anyways, it makes sense to use that for the loops.

Second, some custom attributes names used underscores, which is valid W3C spec:
http://www.w3.org/TR/html-markup/syntax.html#syntax-attributes

> Attribute names must consist of one or more characters other than the space characters, U+0000 NULL, """, "'", ">", "/", "=", the control characters, and any characters that are not defined by Unicode.
