### PR TITLE
Added break statements to Parser Example code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.markDown": false
-  },
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.markDown": "never"
+},
   "eslint.run": "onType"
 }

--- a/readme.md
+++ b/readme.md
@@ -40,15 +40,19 @@ for (const token of Parser.parse(html)) {
     case 'open': {
       console.log(`Opening tag: ${token.name}`);
       console.log('Attributes:', token.attributes);
+      break;
     }
     case 'text': {
       console.log(`Text node: ${token.text}`);
+      break;
     }
     case 'close': {
       console.log(`Closing tag: ${token.name}`);
+      break;
     }
     case 'comment': {
       console.log(`Comment: ${token.text}`);
+      break;
     }
   }
 }


### PR DESCRIPTION
Example Parser code in `readme.md` gives misleading output due to missing `break` statements in `switch`.